### PR TITLE
Stop recommending yaourt

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run drop:
 
 AUR - https://aur.archlinux.org/packages/drop
 
-    yaourt -S drop
+    yay -S drop
 
 ### MacOS
 


### PR DESCRIPTION
yaourt stopped existing and during its time it was a security hassle. yay seems to be a good alternative.